### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through hands-on GitHub exercises, part of the GitHub Certifications program",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the GitHub Skills activity to the extracurricular activities system.

## Changes
- Added "GitHub Skills" entry to the activities dictionary in `src/app.py`
  - Schedule: Wednesdays, 3:30 PM – 5:00 PM
  - Capacity: 25 participants
  - Description references the GitHub Certifications program

## Motivation
The principal announced this activity in a school assembly and students are unable to find it to register. Registrations close at the end of this week.

Closes #6